### PR TITLE
Fix crash on Dialog open by default

### DIFF
--- a/controllers/dialog_controller.js
+++ b/controllers/dialog_controller.js
@@ -17,7 +17,7 @@ export default class extends Controller {
   }
 
   open(e) {
-    e.preventDefault()
+    e?.preventDefault()
     document.body.insertAdjacentHTML('beforeend', this.contentTarget.innerHTML)
     // prevent scroll on body
     document.body.classList.add('overflow-hidden')


### PR DESCRIPTION
Using `Dialog.new(open: true)` was leading to a crash since the stimulus controller tried to call `this.open()` with no `event` but the `open(e)` function expected one.